### PR TITLE
Adjust Linguist to reflect Python-dominant codebase

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Exclude notebooks and site content from language stats
+*.ipynb linguist-documentation
+article.html linguist-documentation
+aurora-article-site/** linguist-documentation
+
+# Generated or binary assets (not counted)
+output_images_and_results/** linguist-generated
+*.png binary
+*.jpg binary
+*.jpeg binary


### PR DESCRIPTION
Exclude *.ipynb and site files from language stats; mark assets as generated. This updates the Languages bar to reflect code (Python).